### PR TITLE
Link ghostty config to macOS Application Support path on darwin

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,11 @@ link ${BASEDIR}/zshrc ~/.zshrc
 link ${BASEDIR}/zsh ~/.zsh
 
 # ghostty
-link ${BASEDIR}/ghostty ~/.config/ghostty
+if [ "$(uname)" = "Darwin" ]; then
+  link "${BASEDIR}/ghostty" ~/Library/Application\ Support/com.mitchellh.ghostty
+else
+  link "${BASEDIR}/ghostty" ~/.config/ghostty
+fi
 
 # claude code
 mkdir -p ~/.claude


### PR DESCRIPTION
Ghostty on macOS reads its config from
~/Library/Application Support/com.mitchellh.ghostty, not ~/.config/ghostty.